### PR TITLE
Fix service worker fetch error handling

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -79,8 +79,8 @@ self.addEventListener('fetch', event => {
             return networkResponse;
         }).catch(error => {
             console.error(`[SW ${CACHE_NAME}] Netzwerk-Fetch fehlgeschlagen für ${event.request.url}:`, error);
-            // Hier könnte man eine Offline-Fallback-Seite anzeigen
-            // throw error; // Fehler weitergeben, damit Browser Standardfehler zeigt
+            // Fehler weitergeben, damit Browser Standardfehler zeigt
+            throw error;
         });
       })
   );


### PR DESCRIPTION
## Summary
- propagate network errors in service worker fetch handler

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6849a095f00c8327bfd42831e5087f32